### PR TITLE
feat: Copland OS風デスクトップUIにリニューアル

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# development screenshots
+copland-os-*.png
+
+# playwright mcp
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Architecture Overview
 
-This is a Next.js 15 personal website (tenori.me) using the App Router with React 19. The site features a personal portfolio with integrated tools and content aggregation.
+This is a Next.js 15 personal website (ivgtr.me) using the App Router with React 19. The site features a personal portfolio with integrated tools and content aggregation.
 
 ### Key Architecture Patterns
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
 
-# 🌟 tenori.me
+# 🌟 ivgtr.me
 
 _ivgtr's personal portfolio website_
 
-[![🌐 Live Site](https://img.shields.io/badge/🌐_Live_Site-tenori.me-4A90E2?style=for-the-badge)](https://tenori.me)
+[![🌐 Live Site](https://img.shields.io/badge/🌐_Live_Site-ivgtr.me-4A90E2?style=for-the-badge)](https://ivgtr.me)
 
-[![Bluesky](https://img.shields.io/badge/Bluesky-0285FF?style=for-the-badge&logo=bluesky&logoColor=fff)](https://bsky.tenori.me/)
+[![Bluesky](https://img.shields.io/badge/Bluesky-0285FF?style=for-the-badge&logo=bluesky&logoColor=fff)](https://bsky.ivgtr.me/)
 [![GitHub](https://img.shields.io/badge/GitHub-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ivgtr)
 
 ---
@@ -19,8 +19,8 @@ _ivgtr's personal portfolio website_
 
 ```bash
 # Clone and install
-git clone https://github.com/ivgtr/tenori.me.git
-cd tenori.me
+git clone https://github.com/ivgtr/ivgtr.me.git
+cd ivgtr.me
 npm install
 
 # Set up environment

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "tenori.me",
+	"name": "ivgtr.me",
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {

--- a/src/app/(components)/AudioPlayerWindow.tsx
+++ b/src/app/(components)/AudioPlayerWindow.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+
+interface Track {
+  name: string;
+  notes: number[];
+  tempo: number;
+}
+
+const tracks: Track[] = [
+  {
+    name: "BGM001.mid",
+    notes: [277.18, 311.13, 369.99, 415.30, 277.18, 311.13, 369.99, 415.30, 277.18, 369.99, 415.30, 466.16, 415.30, 369.99, 311.13],
+    tempo: 300,
+  },
+  {
+    name: "BGM002.mid",
+    notes: [277.18, 277.18, 0, 277.18, 0, 261.63, 277.18, 0, 311.13, 0, 0, 0, 155.56, 0, 0, 0],
+    tempo: 200,
+  },
+  {
+    name: "BGM003.mid",
+    notes: [311.13, 369.99, 415.30, 466.16, 415.30, 369.99, 311.13, 261.63, 293.66, 329.63, 369.99, 415.30, 369.99, 329.63, 293.66, 261.63],
+    tempo: 350,
+  },
+  {
+    name: "BGM004.mid",
+    notes: [261.63, 293.66, 311.13, 349.23, 329.63, 369.99, 415.30, 466.16, 415.30, 369.99, 329.63, 311.13],
+    tempo: 450,
+  },
+  {
+    name: "BGM005.mid",
+    notes: [369.99, 415.30, 466.16, 369.99, 415.30, 466.16, 369.99, 415.30, 466.16, 523.25, 466.16, 415.30, 369.99],
+    tempo: 280,
+  },
+];
+
+export const AudioPlayerWindow = () => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTrackIndex, setCurrentTrackIndex] = useState(0);
+  const [visualizerBars, setVisualizerBars] = useState<number[]>(Array(12).fill(2));
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const vizIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const createAudioContext = () => {
+    if (!audioContextRef.current) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      audioContextRef.current = new (window.AudioContext || (window as any).webkitAudioContext)();
+    }
+    return audioContextRef.current;
+  };
+
+  const playNote = (frequency: number, duration = 0.2) => {
+    const ctx = createAudioContext();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.frequency.setValueAtTime(frequency, ctx.currentTime);
+    osc.type = "square";
+    gain.gain.setValueAtTime(0.1, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
+    osc.start(ctx.currentTime);
+    osc.stop(ctx.currentTime + duration);
+  };
+
+  const handlePlay = async () => {
+    if (!isPlaying) {
+      const ctx = createAudioContext();
+      if (ctx.state === "suspended") await ctx.resume();
+      setIsPlaying(true);
+      const track = tracks[currentTrackIndex];
+      let noteIndex = 0;
+
+      intervalRef.current = setInterval(() => {
+        if (noteIndex < track.notes.length) {
+          const note = track.notes[noteIndex];
+          if (note > 0) playNote(note);
+          noteIndex++;
+        } else {
+          noteIndex = 0;
+        }
+      }, track.tempo);
+
+      vizIntervalRef.current = setInterval(() => {
+        setVisualizerBars(Array.from({ length: 12 }, () => Math.floor(Math.random() * 16) + 2));
+      }, 100);
+    } else {
+      setIsPlaying(false);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (vizIntervalRef.current) clearInterval(vizIntervalRef.current);
+      intervalRef.current = null;
+      vizIntervalRef.current = null;
+      setVisualizerBars(Array(12).fill(2));
+    }
+  };
+
+  const stopAndSwitch = (next: number) => {
+    if (isPlaying) {
+      setIsPlaying(false);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (vizIntervalRef.current) clearInterval(vizIntervalRef.current);
+      intervalRef.current = null;
+      vizIntervalRef.current = null;
+      setVisualizerBars(Array(12).fill(2));
+    }
+    setCurrentTrackIndex(next);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (vizIntervalRef.current) clearInterval(vizIntervalRef.current);
+    };
+  }, []);
+
+  return (
+    <div className="os-audio-player">
+      <div className="os-audio-display">
+        <div className="os-audio-track-name">
+          Now Playing: {tracks[currentTrackIndex].name}
+        </div>
+        <div className="os-audio-visualizer">
+          {visualizerBars.map((h, i) => (
+            <div
+              key={i}
+              className="os-audio-bar"
+              style={{ height: `${h}px` }}
+            />
+          ))}
+        </div>
+      </div>
+      <div className="os-audio-controls">
+        <button
+          className="os-audio-btn"
+          onClick={() => stopAndSwitch(currentTrackIndex > 0 ? currentTrackIndex - 1 : tracks.length - 1)}
+        >
+          &#9198;
+        </button>
+        <button className="os-audio-btn os-audio-btn-play" onClick={handlePlay}>
+          {isPlaying ? "\u23F8" : "\u25B6"}
+        </button>
+        <button
+          className="os-audio-btn"
+          onClick={() => stopAndSwitch(currentTrackIndex < tracks.length - 1 ? currentTrackIndex + 1 : 0)}
+        >
+          &#9197;
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/app/(components)/Contact.tsx
+++ b/src/app/(components)/Contact.tsx
@@ -21,8 +21,8 @@ const accounts = [
 	},
 	{
 		title: "Bluesky",
-		alt: "tenori",
-		url: "https://bsky.app/profile/tenori.me",
+		alt: "ivgtr",
+		url: "https://bsky.app/profile/ivgtr.me",
 		icon: faBluesky,
 		color: "bg-sky-400",
 		emoji: "🦋"

--- a/src/app/(components)/NavigatorWindow.tsx
+++ b/src/app/(components)/NavigatorWindow.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Link from "next/link";
+import { ToolsContent } from "@/app/tools/(components)/ToolsContent";
+import { ArticlesContent } from "@/app/articles/(components)/ArticlesContent";
+
+import { ClopIcon } from "@/app/tools/crop-icon/(components)/ClopIcon";
+import { GlitchImage } from "@/app/tools/glitch-image/(components)/GlitchImage";
+import { ImageToBase64 } from "@/app/tools/image-to-base64/(components)/ImageToBase64";
+import { PixelImage } from "@/app/tools/pixel-image/(components)/PixelImage";
+import { Tategaki } from "@/app/tools/tategaki/(components)/Tategaki";
+import { XCharacterPromptGenerator } from "@/app/tools/x-character-prompt-generator/(components)/XCharacterPromptGenerator";
+import { SideScrollerGame } from "@/app/tools/side-scroller-game/(components)/SideScrollerGame";
+
+type Screen =
+  | { type: "home" }
+  | { type: "tools" }
+  | { type: "articles" }
+  | { type: "tool-detail"; tool: string };
+
+const toolComponents: Record<string, { name: string; component: React.ReactNode }> = {
+  "pixel-image": { name: "画像をドット風にする", component: <PixelImage /> },
+  "crop-icon": { name: "画像を切り抜くやつ", component: <ClopIcon /> },
+  "glitch-image": { name: "画像をマウスでグリッチする", component: <GlitchImage /> },
+  "image-to-base64": { name: "画像をbase64にする", component: <ImageToBase64 /> },
+  "tategaki": { name: "横書きの内容を縦書きするやつ", component: <Tategaki /> },
+  "x-character-prompt-generator": { name: "Xキャラクタープロンプト生成", component: <XCharacterPromptGenerator /> },
+  "side-scroller-game": { name: "横スクロール2Dアクションゲーム", component: <SideScrollerGame /> },
+};
+
+const toolList = [
+  { slug: "pixel-image", name: "画像をドット風にする", category: "画像処理" },
+  { slug: "crop-icon", name: "画像を切り抜くやつ", category: "画像処理" },
+  { slug: "glitch-image", name: "画像をマウスでグリッチする", category: "画像処理" },
+  { slug: "image-to-base64", name: "画像をbase64にする", category: "開発支援" },
+  { slug: "tategaki", name: "横書きの内容を縦書きするやつ", category: "テキスト" },
+  { slug: "x-character-prompt-generator", name: "Xキャラクタープロンプト生成", category: "AI支援" },
+  { slug: "side-scroller-game", name: "横スクロール2Dアクションゲーム", category: "ゲーム" },
+];
+
+export const NavigatorWindow = () => {
+  const [history, setHistory] = useState<Screen[]>([{ type: "home" }]);
+  const screen = history[history.length - 1];
+
+  const navigate = useCallback((next: Screen) => {
+    setHistory((prev) => [...prev, next]);
+  }, []);
+
+  const goBack = useCallback(() => {
+    setHistory((prev) => (prev.length > 1 ? prev.slice(0, -1) : prev));
+  }, []);
+
+  const getPath = () => {
+    switch (screen.type) {
+      case "home":
+        return "/home/ivgtr/";
+      case "tools":
+        return "/home/ivgtr/tools/";
+      case "articles":
+        return "/home/ivgtr/articles/";
+      case "tool-detail":
+        return `/home/ivgtr/tools/${screen.tool}/`;
+    }
+  };
+
+  return (
+    <div className="os-navigator">
+      <div className="os-navigator-toolbar">
+        <button
+          className="os-navigator-back"
+          onClick={goBack}
+          disabled={history.length <= 1}
+        >
+          &larr;
+        </button>
+        <div className="os-navigator-path">{getPath()}</div>
+      </div>
+
+      <div className="os-navigator-content">
+        {screen.type === "home" && (
+          <div className="os-navigator-tree">
+            <button
+              className="os-navigator-folder"
+              onClick={() => navigate({ type: "tools" })}
+            >
+              <span className="os-folder-icon">&#128193;</span>
+              <span>Tools</span>
+            </button>
+            <button
+              className="os-navigator-folder"
+              onClick={() => navigate({ type: "articles" })}
+            >
+              <span className="os-folder-icon">&#128193;</span>
+              <span>Articles</span>
+            </button>
+          </div>
+        )}
+
+        {screen.type === "tools" && (
+          <div className="os-navigator-tree">
+            {toolList.map((tool) => (
+              <button
+                key={tool.slug}
+                className="os-navigator-file"
+                onClick={() => navigate({ type: "tool-detail", tool: tool.slug })}
+              >
+                <span className="os-file-icon">&#128196;</span>
+                <span>{tool.name}</span>
+                <span className="os-file-category">{tool.category}</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {screen.type === "articles" && (
+          <div className="os-navigator-articles">
+            <ArticlesContent />
+          </div>
+        )}
+
+        {screen.type === "tool-detail" && toolComponents[screen.tool] && (
+          <div className="os-navigator-tool-detail">
+            <div className="os-navigator-tool-content">
+              {toolComponents[screen.tool].component}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/app/(components)/ProfileWindow.tsx
+++ b/src/app/(components)/ProfileWindow.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+  faTwitter,
+  faBluesky,
+  faGithub,
+  faSteam,
+} from "@fortawesome/free-brands-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Image from "next/image";
+
+const accounts = [
+  { title: "Twitter", url: "https://twitter.com/ivgtr", icon: faTwitter },
+  { title: "Bluesky", url: "https://bsky.app/profile/ivgtr.me", icon: faBluesky },
+  { title: "Github", url: "https://github.com/ivgtr", icon: faGithub },
+  { title: "Steam", url: "https://steamcommunity.com/id/oyanmi", icon: faSteam },
+];
+
+export const ProfileWindow = () => {
+  return (
+    <div className="os-profile">
+      <div className="os-profile-header">
+        <div className="os-profile-icon">
+          <Image
+            src="/icon.png"
+            alt="ivgtr"
+            width={80}
+            height={80}
+            className="object-cover"
+            priority
+          />
+        </div>
+        <div className="os-profile-info">
+          <div className="os-terminal-line">
+            <span className="os-prompt">$</span> whoami
+          </div>
+          <div className="os-terminal-output">ivgtr</div>
+          <div className="os-terminal-line">
+            <span className="os-prompt">$</span> cat birthday.txt
+          </div>
+          <div className="os-terminal-output">1996/11/12</div>
+        </div>
+      </div>
+
+      <div className="os-profile-section">
+        <div className="os-terminal-line">
+          <span className="os-prompt">$</span> cat likes.json
+        </div>
+        <div className="os-terminal-output os-json">
+          <div>{`{`}</div>
+          <div>&nbsp;&nbsp;{`"games": "Dark Souls / ランスシリーズ",`}</div>
+          <div>&nbsp;&nbsp;{`"music": "藤井風 / 星野源",`}</div>
+          <div>&nbsp;&nbsp;{`"anime": "アイカツ! / プリティーリズム・レインボーライブ / 輪るピングドラム"`}</div>
+          <div>{`}`}</div>
+        </div>
+      </div>
+
+      <div className="os-profile-links">
+        {accounts.map((account) => (
+          <a
+            key={account.title}
+            href={account.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="os-profile-link-btn"
+            title={account.title}
+          >
+            <FontAwesomeIcon icon={account.icon} />
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/app/api/counter/route.ts
+++ b/src/app/api/counter/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 
 const incrementCountSQL = `
   INSERT INTO tb_count (name, count)
-  VALUES ('tenori', 1)
+  VALUES ('ivgtr', 1)
   ON CONFLICT (name)
   DO UPDATE SET count = tb_count.count + 1
   RETURNING count;

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,14 +1,19 @@
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { ArticlesContent } from "./(components)/ArticlesContent";
 
 export default function Articles() {
 	return (
-		<div>
-			<Header to="/" />
-			<main>
-				<h1>Articles</h1>
-				<ArticlesContent />
-			</main>
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="articles"
+					title="Articles - /home/ivgtr/articles/"
+					closable={false}
+					minimizable={false}
+				>
+					<ArticlesContent />
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,11 +5,13 @@ config.autoAddCss = false;
 
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import "@/styles/globals.css";
-import { RetroBackground } from "@/components/retro/RetroBackground";
+import { DesktopBackground } from "@/components/os/DesktopBackground";
 import { KonamiProvider } from "@/components/retro/KonamiProvider";
+import { MenuBarProvider } from "@/components/os/MenuBarContext";
+import { MenuBar } from "@/components/os/MenuBar";
 
 export const metadata: Metadata = {
-	title: "tenori.me - 個人サイト",
+	title: "ivgtr.me - 個人サイト",
 	description: "卵の殻を破らねば、雛鳥は生まれずに死んでいく。",
 };
 
@@ -20,10 +22,13 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="ja">
-			<body className={`${marumonica.variable} ${aahub.variable} retro-site`}>
+			<body className={`${marumonica.variable} ${aahub.variable} os-site`}>
 				<KonamiProvider>
-					<RetroBackground />
-					{children}
+					<MenuBarProvider>
+						<DesktopBackground />
+						<MenuBar />
+						<main className="os-workspace">{children}</main>
+					</MenuBarProvider>
 				</KonamiProvider>
 			</body>
 		</html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,99 +1,110 @@
-import { Icon } from "@/components/Icon";
-import { Profile } from "./(components)/Profile";
-import { PageLink } from "./(components)/PageLink";
-import { Contact } from "./(components)/Contact";
-import { Footer } from "@/components/Footer";
-import { RetroBorder } from "@/components/retro/RetroBorder";
-import { BlinkingText } from "@/components/retro/BlinkingText";
-import { Marquee } from "@/components/retro/Marquee";
-import { RetroVisitorCounter } from "@/components/retro/RetroVisitorCounter";
-import { DigitalClock } from "@/components/retro/DigitalClock";
-import { WebRing } from "@/components/retro/WebRing";
-import { RetroGuestbook } from "@/components/retro/RetroGuestbook";
-import { RetroMidiPlayer } from "@/components/retro/RetroMidiPlayer";
-import { AAWelcome } from "@/components/retro/AAWelcome";
-import { AABoard } from "@/components/retro/AABoard";
-import { AAFooter } from "@/components/retro/AAFooter";
+"use client";
+
+import { useEffect } from "react";
+import { Window } from "@/components/os/Window";
+import { StatusBar } from "@/components/os/StatusBar";
+import { useWindowManager } from "@/hooks/useWindowManager";
+import { useMenuBar } from "@/components/os/MenuBarContext";
+import { ProfileWindow } from "./(components)/ProfileWindow";
+import { NavigatorWindow } from "./(components)/NavigatorWindow";
+import { AudioPlayerWindow } from "./(components)/AudioPlayerWindow";
+
+const initialWindows = [
+	{ id: "profile", isOpen: true, isMinimized: false, position: { x: 16, y: 16 } },
+	{ id: "navigator", isOpen: true, isMinimized: false, position: { x: 380, y: 16 } },
+	{ id: "audio", isOpen: true, isMinimized: false, position: { x: 16, y: 480 } },
+];
+
+const windowTitles: Record<string, string> = {
+	profile: "Profile - ivgtr",
+	navigator: "Navigator - /home/ivgtr/",
+	audio: "Audio Player",
+};
 
 export default function Home() {
+	const { windows, focus, close, minimize, restore, getWindow } =
+		useWindowManager(initialWindows);
+	const { setActiveTitle } = useMenuBar();
+
+	const profileWin = getWindow("profile")!;
+	const navigatorWin = getWindow("navigator")!;
+	const audioWin = getWindow("audio")!;
+
+	useEffect(() => {
+		const activeWindows = windows.filter((w) => w.isOpen && !w.isMinimized);
+		if (activeWindows.length === 0) {
+			setActiveTitle("");
+			return;
+		}
+		const topWindow = activeWindows.reduce((a, b) =>
+			a.zIndex > b.zIndex ? a : b,
+		);
+		setActiveTitle(windowTitles[topWindow.id] ?? "");
+	}, [windows, setActiveTitle]);
+
+	const minimizedWindows = windows
+		.filter((w) => w.isOpen && w.isMinimized)
+		.map((w) => ({
+			id: w.id,
+			title:
+				w.id === "profile"
+					? "Profile"
+					: w.id === "navigator"
+						? "Navigator"
+						: "Audio Player",
+			onRestore: () => restore(w.id),
+		}));
+
 	return (
-		<div className="retro-layout min-h-screen">
-			<Marquee className="mb-4">
-				🌟 ようこそ tenori.me へ 🌟 個人サイト運営中 🌟 リンクフリー 🌟 相互リンク募集中 🌟
-			</Marquee>
-			
-			<AAWelcome />
-			
-			<div className="container mx-auto px-4 grid grid-cols-1 lg:grid-cols-4 gap-4 mt-4">
-				{/* Left Sidebar */}
-				<aside className="lg:col-span-1 space-y-4">
-					<RetroVisitorCounter />
-					<DigitalClock />
-					<RetroMidiPlayer />
-					<WebRing />
-				</aside>
+		<>
+			<div className="os-desktop-windows">
+				<Window
+					id="profile"
+					title="Profile - ivgtr"
+					defaultPosition={profileWin.position}
+					defaultSize={{ width: 320 }}
+					isOpen={profileWin.isOpen}
+					isMinimized={profileWin.isMinimized}
+					zIndex={profileWin.zIndex}
+					closable={false}
+					onMinimize={() => minimize("profile")}
+					onFocus={() => focus("profile")}
+				>
+					<ProfileWindow />
+				</Window>
 
-				{/* Main Content */}
-				<main className="lg:col-span-2">
-					<RetroBorder variant="gradient" className="mb-6">
-						<div className="text-center">
-							<h1 className="text-4xl font-bold mb-2 text-cyan-400">
-								<BlinkingText>✨ tenori.me ✨</BlinkingText>
-							</h1>
-							<p className="text-yellow-300 text-sm">～ 個人サイト ～</p>
-						</div>
-					</RetroBorder>
+				<Window
+					id="navigator"
+					title="Navigator - /home/ivgtr/"
+					defaultPosition={navigatorWin.position}
+					defaultSize={{ width: 520, height: 420 }}
+					isOpen={navigatorWin.isOpen}
+					isMinimized={navigatorWin.isMinimized}
+					zIndex={navigatorWin.zIndex}
+					closable={false}
+					onMinimize={() => minimize("navigator")}
+					onFocus={() => focus("navigator")}
+				>
+					<NavigatorWindow />
+				</Window>
 
-					<RetroBorder variant="classic" className="mb-6">
-						<section className="bg-white text-black">
-							<h2 className="text-2xl font-bold mb-4 text-purple-800 border-b-2 border-purple-800 pb-2">
-								💫 About me 💫
-							</h2>
-							<div className="flex flex-col md:flex-row gap-4">
-								<div className="flex-shrink-0">
-									<Icon />
-								</div>
-								<div className="flex-1">
-									<Profile />
-								</div>
-							</div>
-						</section>
-					</RetroBorder>
-
-					<RetroBorder variant="classic" className="mb-6">
-						<section className="bg-white text-black">
-							<h2 className="text-2xl font-bold mb-4 text-purple-800 border-b-2 border-purple-800 pb-2">
-								📧 Contact 📧
-							</h2>
-							<Contact />
-						</section>
-					</RetroBorder>
-
-					<RetroBorder variant="classic" className="mb-6">
-						<section className="bg-white text-black">
-							<h2 className="text-2xl font-bold mb-4 text-purple-800 border-b-2 border-purple-800 pb-2">
-								🔗 Link 🔗
-							</h2>
-							<PageLink />
-						</section>
-					</RetroBorder>
-				</main>
-
-				{/* Right Sidebar */}
-				<aside className="lg:col-span-1 space-y-4">
-					<RetroGuestbook />
-				</aside>
+				<Window
+					id="audio"
+					title="Audio Player"
+					defaultPosition={audioWin.position}
+					defaultSize={{ width: 340 }}
+					isOpen={audioWin.isOpen}
+					isMinimized={audioWin.isMinimized}
+					zIndex={audioWin.zIndex}
+					onClose={() => close("audio")}
+					onMinimize={() => minimize("audio")}
+					onFocus={() => focus("audio")}
+				>
+					<AudioPlayerWindow />
+				</Window>
 			</div>
 
-			<div className="container mx-auto px-4 mt-6">
-				<AABoard />
-			</div>
-
-			<div className="mt-6">
-				<AAFooter />
-			</div>
-
-			<Footer />
-		</div>
+			<StatusBar minimizedWindows={minimizedWindows} />
+		</>
 	);
 }

--- a/src/app/tools/crop-icon/page.tsx
+++ b/src/app/tools/crop-icon/page.tsx
@@ -1,41 +1,19 @@
-import clsx from "clsx";
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { ClopIcon } from "./(components)/ClopIcon";
 
 export default function ClopIconPage() {
 	return (
-		<div>
-			<Header to="/tools" />
-			<main>
-				<h2>画像を切り抜くやつ</h2>
-				<section>
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="crop-icon"
+					title="画像を切り抜くやつ"
+					closable={false}
+					minimizable={false}
+				>
 					<ClopIcon />
-				</section>
-				<section>
-					<h3>使い方</h3>
-					<ul className="list">
-						<li>
-							<p>画像URLに切り抜きたい画像のURLを入力</p>
-						</li>
-						<li>
-							<p>形を選択</p>
-						</li>
-					</ul>
-				</section>
-				<section>
-					<h3>source</h3>
-					<ul>
-						<li>
-							<a
-								href="https://github.com/ivgtr/crop-icon"
-								className={clsx("hover:underline", "text-blue-500")}
-							>
-								ivgtr/crop-icon
-							</a>
-						</li>
-					</ul>
-				</section>
-			</main>
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/app/tools/glitch-image/page.tsx
+++ b/src/app/tools/glitch-image/page.tsx
@@ -1,30 +1,19 @@
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { GlitchImage } from "./(components)/GlitchImage";
 
 export default function GlitchImagePage() {
 	return (
-		<div>
-			<Header to="/tools" />
-			<main>
-				<h2>画像をマウスでグリッチする</h2>
-				<section>
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="glitch-image"
+					title="画像をマウスでグリッチする"
+					closable={false}
+					minimizable={false}
+				>
 					<GlitchImage />
-				</section>
-				<section>
-					<h3>使い方</h3>
-					<ul className="list">
-						<li>
-							<p>画像を読み込む</p>
-						</li>
-						<li>
-							<p>ぐりぐりする</p>
-						</li>
-						<li>
-							<p>PCでしか動きません</p>
-						</li>
-					</ul>
-				</section>
-			</main>
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/app/tools/image-to-base64/page.tsx
+++ b/src/app/tools/image-to-base64/page.tsx
@@ -1,16 +1,19 @@
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { ImageToBase64 } from "./(components)/ImageToBase64";
 
 export default function ImageToBase64Page() {
 	return (
-		<div>
-			<Header to="/tools" />
-			<main>
-				<h2>画像をbase64にする</h2>
-				<section>
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="image-to-base64"
+					title="画像をbase64にする"
+					closable={false}
+					minimizable={false}
+				>
 					<ImageToBase64 />
-				</section>
-			</main>
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,27 +1,19 @@
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { ToolsContent } from "./(components)/ToolsContent";
-import { RetroBorder } from "@/components/retro/RetroBorder";
-import { BlinkingText } from "@/components/retro/BlinkingText";
 
 export default function Tools() {
 	return (
-		<div className="retro-layout min-h-screen">
-			<Header to="/" />
-			<main className="container mx-auto px-4 py-8">
-				<RetroBorder variant="gradient" className="mb-6">
-					<div className="text-center">
-						<h1 className="text-2xl font-bold mb-4 text-yellow-300">
-							<BlinkingText>🔧 便利ツール集 🔧</BlinkingText>
-						</h1>
-						<div className="text-sm text-cyan-400">
-							※ 個人製作のツールです。バグがあっても泣かないでください ※
-						</div>
-					</div>
-				</RetroBorder>
-				<div className="text-green-400 font-mono">
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="tools-list"
+					title="Tools - /home/ivgtr/tools/"
+					closable={false}
+					minimizable={false}
+				>
 					<ToolsContent />
-				</div>
-			</main>
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/app/tools/pixel-image/page.tsx
+++ b/src/app/tools/pixel-image/page.tsx
@@ -1,44 +1,19 @@
-import clsx from "clsx";
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { PixelImage } from "./(components)/PixelImage";
 
 export default function PixelImagePage() {
 	return (
-		<div>
-			<Header to="/tools" />
-			<main>
-				<h2>画像をドット風にする</h2>
-				<section>
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="pixel-image"
+					title="画像をドット風にする"
+					closable={false}
+					minimizable={false}
+				>
 					<PixelImage />
-				</section>
-				<section>
-					<h3>使い方</h3>
-					<ul className="list">
-						<li>
-							<p>画像URLにドット風にしたい画像のURLを入力</p>
-						</li>
-						<li>
-							<p>ドットの大きさ（セルサイズ）を調整</p>
-						</li>
-						<li>
-							<p>色の範囲（Kサイズ）を調整</p>
-						</li>
-					</ul>
-				</section>
-				<section>
-					<h3>source</h3>
-					<ul>
-						<li>
-							<a
-								href="https://github.com/ivgtr/pixel-image"
-								className={clsx("hover:underline", "text-blue-500")}
-							>
-								ivgtr/pixel-image
-							</a>
-						</li>
-					</ul>
-				</section>
-			</main>
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/app/tools/side-scroller-game/page.tsx
+++ b/src/app/tools/side-scroller-game/page.tsx
@@ -1,16 +1,19 @@
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { SideScrollerGame } from "./(components)/SideScrollerGame";
 
 export default function SideScrollerGamePage() {
 	return (
-		<div>
-			<Header to="/tools" />
-			<main>
-				<h2>横スクロール2Dアクションゲーム</h2>
-				<section>
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="side-scroller-game"
+					title="横スクロール2Dアクションゲーム"
+					closable={false}
+					minimizable={false}
+				>
 					<SideScrollerGame />
-				</section>
-			</main>
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/app/tools/tategaki/page.tsx
+++ b/src/app/tools/tategaki/page.tsx
@@ -1,16 +1,19 @@
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { Tategaki } from "./(components)/Tategaki";
 
 export default function TategakiPage() {
 	return (
-		<div>
-			<Header to="/tools" />
-			<main>
-				<h2>横書きの内容を縦書きするやつ</h2>
-				<section>
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="tategaki"
+					title="横書きの内容を縦書きするやつ"
+					closable={false}
+					minimizable={false}
+				>
 					<Tategaki />
-				</section>
-			</main>
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/app/tools/x-character-prompt-generator/page.tsx
+++ b/src/app/tools/x-character-prompt-generator/page.tsx
@@ -1,14 +1,19 @@
-import { Header } from "@/components/Header";
+import { Window } from "@/components/os/Window";
 import { XCharacterPromptGenerator } from "./(components)/XCharacterPromptGenerator";
 
 export default function XCharacterPromptGeneratorPage() {
 	return (
-		<div>
-			<Header to="/tools" />
-			<main>
-				<h1>X Character Prompt Generator</h1>
-				<XCharacterPromptGenerator />
-			</main>
+		<div className="os-subpage-workspace">
+			<div className="os-subpage-window">
+				<Window
+					id="x-character-prompt-generator"
+					title="Xキャラクタープロンプト生成"
+					closable={false}
+					minimizable={false}
+				>
+					<XCharacterPromptGenerator />
+				</Window>
+			</div>
 		</div>
 	);
 }

--- a/src/components/os/DesktopBackground.tsx
+++ b/src/components/os/DesktopBackground.tsx
@@ -1,0 +1,3 @@
+export const DesktopBackground = () => {
+  return <div className="os-desktop-bg" />;
+};

--- a/src/components/os/MenuBar.tsx
+++ b/src/components/os/MenuBar.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "next/link";
+import { DigitalClock } from "@/components/retro/DigitalClock";
+import { useMenuBar } from "@/components/os/MenuBarContext";
+
+export const MenuBar = () => {
+  const { activeTitle } = useMenuBar();
+
+  return (
+    <nav className="os-menubar">
+      <div className="os-menubar-left">
+        <Link href="/" className="os-menubar-brand">
+          ivgtr.me
+        </Link>
+      </div>
+      <div className="os-menubar-center">
+        {activeTitle && (
+          <span className="os-menubar-active-title">{activeTitle}</span>
+        )}
+      </div>
+      <div className="os-menubar-right">
+        <DigitalClock />
+      </div>
+    </nav>
+  );
+};

--- a/src/components/os/MenuBarContext.tsx
+++ b/src/components/os/MenuBarContext.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+interface MenuBarContextValue {
+	activeTitle: string;
+	setActiveTitle: (title: string) => void;
+}
+
+const MenuBarContext = createContext<MenuBarContextValue>({
+	activeTitle: "",
+	setActiveTitle: () => {},
+});
+
+export function MenuBarProvider({ children }: { children: ReactNode }) {
+	const [activeTitle, setActiveTitle] = useState("");
+
+	return (
+		<MenuBarContext value={{ activeTitle, setActiveTitle }}>
+			{children}
+		</MenuBarContext>
+	);
+}
+
+export function useMenuBar() {
+	return useContext(MenuBarContext);
+}

--- a/src/components/os/StatusBar.tsx
+++ b/src/components/os/StatusBar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { RetroVisitorCounter } from "@/components/retro/RetroVisitorCounter";
+
+interface MinimizedWindow {
+  id: string;
+  title: string;
+  onRestore: () => void;
+}
+
+interface StatusBarProps {
+  minimizedWindows?: MinimizedWindow[];
+}
+
+export const StatusBar = ({ minimizedWindows = [] }: StatusBarProps) => {
+  return (
+    <div className="os-statusbar">
+      <div className="os-statusbar-left">
+        <span className="os-statusbar-indicator" />
+        <span>Connection: OK</span>
+      </div>
+      <div className="os-statusbar-center">
+        {minimizedWindows.map((w) => (
+          <button
+            key={w.id}
+            className="os-statusbar-window-btn"
+            onClick={w.onRestore}
+          >
+            {w.title}
+          </button>
+        ))}
+      </div>
+      <div className="os-statusbar-right">
+        <RetroVisitorCounter />
+      </div>
+    </div>
+  );
+};

--- a/src/components/os/Window.tsx
+++ b/src/components/os/Window.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useDraggable } from "@/hooks/useDraggable";
+
+interface WindowProps {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+  defaultPosition?: { x: number; y: number };
+  defaultSize?: { width: number | string; height?: number | string };
+  isOpen?: boolean;
+  isMinimized?: boolean;
+  zIndex?: number;
+  closable?: boolean;
+  minimizable?: boolean;
+  onClose?: () => void;
+  onMinimize?: () => void;
+  onFocus?: () => void;
+}
+
+export const Window = ({
+  id,
+  title,
+  children,
+  defaultPosition = { x: 0, y: 0 },
+  defaultSize,
+  isOpen = true,
+  isMinimized = false,
+  zIndex = 10,
+  closable = true,
+  minimizable = true,
+  onClose,
+  onMinimize,
+  onFocus,
+}: WindowProps) => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+
+  const { elementRef, dragHandleProps, style: dragStyle } = useDraggable({
+    defaultPosition,
+    disabled: isMobile,
+  });
+
+  const [visible, setVisible] = useState(isOpen && !isMinimized);
+
+  useEffect(() => {
+    if (isOpen && !isMinimized) {
+      setVisible(true);
+    } else {
+      const t = setTimeout(() => setVisible(false), 200);
+      return () => clearTimeout(t);
+    }
+  }, [isOpen, isMinimized]);
+
+  if (!visible && (!isOpen || isMinimized)) return null;
+
+  const sizeStyle: React.CSSProperties = defaultSize
+    ? {
+        width: typeof defaultSize.width === "number" ? `${defaultSize.width}px` : defaultSize.width,
+        height: defaultSize.height
+          ? typeof defaultSize.height === "number"
+            ? `${defaultSize.height}px`
+            : defaultSize.height
+          : undefined,
+      }
+    : {};
+
+  return (
+    <div
+      ref={elementRef}
+      className={`os-window ${isOpen && !isMinimized ? "os-window-open" : "os-window-close"}`}
+      style={{
+        ...dragStyle,
+        ...sizeStyle,
+        zIndex,
+        position: isMobile ? "relative" : "absolute",
+      }}
+      onPointerDown={onFocus}
+      data-window-id={id}
+    >
+      <div className="os-titlebar" {...dragHandleProps}>
+        <div className="os-titlebar-buttons">
+          {minimizable && (
+            <button
+              className="os-titlebar-btn os-titlebar-btn-minimize"
+              onClick={(e) => {
+                e.stopPropagation();
+                onMinimize?.();
+              }}
+              aria-label="最小化"
+            >
+              <span>_</span>
+            </button>
+          )}
+          {closable && (
+            <button
+              className="os-titlebar-btn os-titlebar-btn-close"
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose?.();
+              }}
+              aria-label="閉じる"
+            >
+              <span>&times;</span>
+            </button>
+          )}
+        </div>
+        <div className="os-titlebar-title">{title}</div>
+      </div>
+      <div className="os-window-content">{children}</div>
+    </div>
+  );
+};

--- a/src/components/os/index.ts
+++ b/src/components/os/index.ts
@@ -1,0 +1,4 @@
+export { Window } from "./Window";
+export { MenuBar } from "./MenuBar";
+export { StatusBar } from "./StatusBar";
+export { DesktopBackground } from "./DesktopBackground";

--- a/src/components/retro/DigitalClock.tsx
+++ b/src/components/retro/DigitalClock.tsx
@@ -4,41 +4,25 @@ import { useState, useEffect } from "react";
 
 export const DigitalClock = () => {
   const [time, setTime] = useState<string>("");
-  const [date, setDate] = useState<string>("");
 
   useEffect(() => {
     const updateDateTime = () => {
       const now = new Date();
-      const timeString = now.toLocaleTimeString("ja-JP", { 
+      const timeString = now.toLocaleTimeString("ja-JP", {
         hour12: false,
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit"
       });
-      const dateString = now.toLocaleDateString("ja-JP", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        weekday: "short"
-      });
-      
       setTime(timeString);
-      setDate(dateString);
     };
 
     updateDateTime();
     const interval = setInterval(updateDateTime, 1000);
-
     return () => clearInterval(interval);
   }, []);
 
   return (
-    <div className="bg-black border-2 border-red-400 p-3 font-mono text-center">
-      <div className="text-red-400 text-sm mb-1">⏰ DIGITAL CLOCK ⏰</div>
-      <div className="bg-gray-900 border border-red-400 p-2 mb-1">
-        <div className="text-red-400 text-lg font-bold">{time}</div>
-      </div>
-      <div className="text-red-400 text-xs">{date}</div>
-    </div>
+    <span className="os-clock">{time}</span>
   );
 };

--- a/src/components/retro/RetroVisitorCounter.tsx
+++ b/src/components/retro/RetroVisitorCounter.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import useSWR from "swr/immutable";
-import { BlinkingText } from "./BlinkingText";
 
 type Counter = {
   count: number;
@@ -17,28 +16,12 @@ export const RetroVisitorCounter = () => {
   };
 
   return (
-    <div className="bg-black border-2 border-green-400 p-3 font-mono text-center">
-      <div className="text-green-400 text-sm mb-1">💻 VISITOR COUNTER 💻</div>
-      <div className="bg-gray-900 border border-green-400 p-2 mb-2">
-        {error ? (
-          <BlinkingText className="text-red-400">ERROR</BlinkingText>
-        ) : !data ? (
-          <span className="text-green-400">------</span>
-        ) : (
-          <span className="text-green-400 text-lg font-bold">
-            {formatCount(data.count)}
-          </span>
-        )}
-      </div>
-      <div className="text-green-400 text-xs">
-        {error ? (
-          "接続エラー"
-        ) : !data ? (
-          "読み込み中..."
-        ) : (
-          `あなたは${data.count}人目の訪問者です`
-        )}
-      </div>
-    </div>
+    <span className="os-visitor-inline">
+      {error
+        ? "ERR"
+        : !data
+          ? "------"
+          : `Visitors: ${formatCount(data.count)}`}
+    </span>
   );
 };

--- a/src/hooks/useDraggable.ts
+++ b/src/hooks/useDraggable.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface UseDraggableOptions {
+  defaultPosition?: Position;
+  disabled?: boolean;
+}
+
+export function useDraggable({ defaultPosition = { x: 0, y: 0 }, disabled = false }: UseDraggableOptions = {}) {
+  const [position, setPosition] = useState<Position>(defaultPosition);
+  const isDragging = useRef(false);
+  const dragStart = useRef<Position>({ x: 0, y: 0 });
+  const elementRef = useRef<HTMLDivElement>(null);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (disabled) return;
+      isDragging.current = true;
+      dragStart.current = {
+        x: e.clientX - position.x,
+        y: e.clientY - position.y,
+      };
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [disabled, position],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDragging.current) return;
+      let newX = e.clientX - dragStart.current.x;
+      let newY = e.clientY - dragStart.current.y;
+
+      const el = elementRef.current;
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        const parentRect = el.offsetParent?.getBoundingClientRect() ?? {
+          left: 0,
+          top: 0,
+          width: window.innerWidth,
+          height: window.innerHeight,
+        };
+        const maxX = parentRect.width - rect.width;
+        const maxY = parentRect.height - rect.height;
+        newX = Math.max(0, Math.min(newX, maxX));
+        newY = Math.max(0, Math.min(newY, maxY));
+      }
+
+      setPosition({ x: newX, y: newY });
+    },
+    [],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    isDragging.current = false;
+  }, []);
+
+  return {
+    position,
+    setPosition,
+    elementRef,
+    dragHandleProps: disabled
+      ? {}
+      : {
+          onPointerDown: handlePointerDown,
+          onPointerMove: handlePointerMove,
+          onPointerUp: handlePointerUp,
+          style: { cursor: "grab", touchAction: "none" } as React.CSSProperties,
+        },
+    style: disabled
+      ? {}
+      : ({
+          left: `${position.x}px`,
+          top: `${position.y}px`,
+        } as React.CSSProperties),
+  };
+}

--- a/src/hooks/useWindowManager.ts
+++ b/src/hooks/useWindowManager.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useReducer, useCallback } from "react";
+
+export interface WindowState {
+  id: string;
+  isOpen: boolean;
+  isMinimized: boolean;
+  zIndex: number;
+  position: { x: number; y: number };
+}
+
+type Action =
+  | { type: "focus"; id: string }
+  | { type: "close"; id: string }
+  | { type: "minimize"; id: string }
+  | { type: "restore"; id: string }
+  | { type: "open"; id: string }
+  | { type: "updatePosition"; id: string; position: { x: number; y: number } };
+
+let globalZCounter = 10;
+
+function reducer(state: WindowState[], action: Action): WindowState[] {
+  switch (action.type) {
+    case "focus":
+      globalZCounter++;
+      return state.map((w) =>
+        w.id === action.id ? { ...w, zIndex: globalZCounter } : w,
+      );
+    case "close":
+      return state.map((w) =>
+        w.id === action.id ? { ...w, isOpen: false } : w,
+      );
+    case "minimize":
+      return state.map((w) =>
+        w.id === action.id ? { ...w, isMinimized: true } : w,
+      );
+    case "restore":
+      globalZCounter++;
+      return state.map((w) =>
+        w.id === action.id ? { ...w, isMinimized: false, isOpen: true, zIndex: globalZCounter } : w,
+      );
+    case "open":
+      globalZCounter++;
+      return state.map((w) =>
+        w.id === action.id ? { ...w, isOpen: true, isMinimized: false, zIndex: globalZCounter } : w,
+      );
+    case "updatePosition":
+      return state.map((w) =>
+        w.id === action.id ? { ...w, position: action.position } : w,
+      );
+    default:
+      return state;
+  }
+}
+
+export function useWindowManager(initialWindows: Omit<WindowState, "zIndex">[]) {
+  const [windows, dispatch] = useReducer(
+    reducer,
+    initialWindows.map((w, i) => ({ ...w, zIndex: 10 + i })),
+  );
+
+  const focus = useCallback((id: string) => dispatch({ type: "focus", id }), []);
+  const close = useCallback((id: string) => dispatch({ type: "close", id }), []);
+  const minimize = useCallback((id: string) => dispatch({ type: "minimize", id }), []);
+  const restore = useCallback((id: string) => dispatch({ type: "restore", id }), []);
+  const open = useCallback((id: string) => dispatch({ type: "open", id }), []);
+
+  const getWindow = useCallback(
+    (id: string) => windows.find((w) => w.id === id),
+    [windows],
+  );
+
+  return { windows, focus, close, minimize, restore, open, getWindow };
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -454,3 +454,637 @@ ul.list {
 		}
 	}
 }
+
+/* ============================================
+   Copland OS Theme
+   ============================================ */
+
+:root {
+	--os-bg: #050510;
+	--os-window-bg: #0c0c1a;
+	--os-titlebar: #1a1a2e;
+	--os-border: #1e3a5f;
+	--os-accent: #00d4ff;
+	--os-accent-dim: #0a7ea4;
+	--os-text: #b0c4de;
+	--os-text-bright: #e0f0ff;
+	--os-text-dim: #5a6a7a;
+	--os-green: #00ff88;
+	--os-red: #ff4466;
+	--os-yellow: #ffcc00;
+}
+
+/* OS Site Global */
+.os-site {
+	font-family: var(--font-marumonica), "MS Gothic", monospace !important;
+	cursor: crosshair;
+	background: var(--os-bg);
+	color: var(--os-text);
+	overflow: hidden;
+	height: 100vh;
+	display: flex;
+	flex-direction: column;
+}
+
+.os-site a,
+.os-site button {
+	cursor: pointer;
+}
+
+.os-site input,
+.os-site textarea,
+.os-site select {
+	cursor: text;
+	background: #0a0a18;
+	color: var(--os-text-bright);
+	border: 1px solid var(--os-border);
+}
+
+/* Desktop Background */
+.os-desktop-bg {
+	position: fixed;
+	inset: 0;
+	z-index: -1;
+	background-color: var(--os-bg);
+	background-image:
+		linear-gradient(rgba(0, 212, 255, 0.03) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(0, 212, 255, 0.03) 1px, transparent 1px);
+	background-size: 40px 40px;
+}
+
+.os-desktop-bg::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: repeating-linear-gradient(
+		0deg,
+		transparent,
+		transparent 2px,
+		rgba(0, 0, 0, 0.03) 2px,
+		rgba(0, 0, 0, 0.03) 4px
+	);
+	pointer-events: none;
+}
+
+/* Menu Bar */
+.os-menubar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: 32px;
+	padding: 0 12px;
+	background: var(--os-titlebar);
+	border-bottom: 1px solid var(--os-border);
+	flex-shrink: 0;
+	z-index: 9999;
+	gap: 8px;
+}
+
+.os-menubar-left {
+	flex-shrink: 0;
+}
+
+.os-menubar-brand {
+	color: var(--os-accent);
+	font-weight: bold;
+	font-size: 14px;
+	text-decoration: none;
+	letter-spacing: 1px;
+}
+
+.os-menubar-center {
+	display: flex;
+	gap: 4px;
+}
+
+.os-menubar-item {
+	color: var(--os-text);
+	text-decoration: none;
+	font-size: 13px;
+	padding: 2px 10px;
+	border-radius: 2px;
+	transition: background 0.15s, color 0.15s;
+}
+
+.os-menubar-item:hover {
+	background: var(--os-border);
+	color: var(--os-text-bright);
+}
+
+.os-menubar-right {
+	flex-shrink: 0;
+}
+
+/* Digital Clock (MenuBar) */
+.os-clock {
+	color: var(--os-accent);
+	font-size: 13px;
+	font-variant-numeric: tabular-nums;
+	letter-spacing: 1px;
+}
+
+/* Status Bar */
+.os-statusbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: 28px;
+	padding: 0 12px;
+	background: var(--os-titlebar);
+	border-top: 1px solid var(--os-border);
+	flex-shrink: 0;
+	z-index: 9999;
+	font-size: 12px;
+	gap: 8px;
+}
+
+.os-statusbar-left {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--os-text-dim);
+	flex-shrink: 0;
+}
+
+.os-statusbar-indicator {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background: var(--os-green);
+	box-shadow: 0 0 4px var(--os-green);
+}
+
+.os-statusbar-center {
+	display: flex;
+	gap: 4px;
+	overflow-x: auto;
+	flex: 1;
+	justify-content: center;
+}
+
+.os-statusbar-window-btn {
+	background: rgba(0, 212, 255, 0.1);
+	border: 1px solid var(--os-border);
+	color: var(--os-text);
+	font-size: 11px;
+	padding: 1px 8px;
+	cursor: pointer;
+	transition: background 0.15s;
+	white-space: nowrap;
+}
+
+.os-statusbar-window-btn:hover {
+	background: rgba(0, 212, 255, 0.2);
+	color: var(--os-text-bright);
+}
+
+.os-statusbar-right {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--os-text-dim);
+	font-size: 11px;
+	flex-shrink: 0;
+}
+
+/* Workspace */
+.os-workspace {
+	flex: 1;
+	position: relative;
+	overflow: hidden;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	max-width: 100%;
+	margin: 0;
+}
+
+/* Desktop windows container (used on home page) */
+.os-desktop-windows {
+	flex: 1;
+	position: relative;
+	overflow: hidden;
+	padding: 8px;
+}
+
+/* Window */
+.os-window {
+	background: var(--os-window-bg);
+	border: 1px solid var(--os-border);
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.6), 0 0 1px rgba(0, 212, 255, 0.2);
+	display: flex;
+	flex-direction: column;
+	max-height: calc(100vh - 80px);
+}
+
+.os-window-open {
+	animation: os-window-in 0.2s ease-out forwards;
+}
+
+.os-window-close {
+	animation: os-window-out 0.2s ease-in forwards;
+	pointer-events: none;
+}
+
+@keyframes os-window-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes os-window-out {
+	from { opacity: 1; }
+	to { opacity: 0; }
+}
+
+/* Title Bar */
+.os-titlebar {
+	display: flex;
+	align-items: center;
+	height: 28px;
+	padding: 0 8px;
+	background: var(--os-titlebar);
+	border-bottom: 1px solid var(--os-border);
+	flex-shrink: 0;
+	gap: 8px;
+	user-select: none;
+}
+
+.os-titlebar-buttons {
+	display: flex;
+	gap: 4px;
+	flex-shrink: 0;
+}
+
+.os-titlebar-btn {
+	width: 16px;
+	height: 16px;
+	border: 1px solid var(--os-border);
+	background: transparent;
+	color: var(--os-text-dim);
+	font-size: 11px;
+	line-height: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	padding: 0;
+	transition: background 0.15s, color 0.15s;
+}
+
+.os-titlebar-btn:hover {
+	background: var(--os-border);
+	color: var(--os-text-bright);
+}
+
+.os-titlebar-btn-close:hover {
+	background: var(--os-red);
+	color: white;
+}
+
+.os-titlebar-title {
+	color: var(--os-text);
+	font-size: 12px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	flex: 1;
+}
+
+/* Window Content */
+.os-window-content {
+	flex: 1;
+	overflow: auto;
+	padding: 12px;
+	font-size: 14px;
+}
+
+/* Profile Window */
+.os-profile {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.os-profile-header {
+	display: flex;
+	gap: 12px;
+	align-items: flex-start;
+}
+
+.os-profile-icon {
+	width: 80px;
+	height: 80px;
+	flex-shrink: 0;
+	border: 1px solid var(--os-border);
+	overflow: hidden;
+}
+
+.os-profile-icon img {
+	border-radius: 0;
+}
+
+.os-profile-info {
+	flex: 1;
+	font-size: 13px;
+}
+
+.os-terminal-line {
+	color: var(--os-text-dim);
+	margin-bottom: 2px;
+}
+
+.os-prompt {
+	color: var(--os-accent);
+	margin-right: 6px;
+}
+
+.os-terminal-output {
+	color: var(--os-text-bright);
+	margin-bottom: 8px;
+	padding-left: 16px;
+}
+
+.os-json {
+	font-size: 12px;
+	color: var(--os-green);
+}
+
+.os-profile-section {
+	border-top: 1px solid var(--os-border);
+	padding-top: 8px;
+}
+
+.os-profile-links {
+	display: flex;
+	gap: 8px;
+	border-top: 1px solid var(--os-border);
+	padding-top: 10px;
+}
+
+.os-profile-link-btn {
+	width: 32px;
+	height: 32px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid var(--os-border);
+	background: transparent;
+	color: var(--os-accent);
+	font-size: 16px;
+	text-decoration: none;
+	transition: background 0.15s, box-shadow 0.15s;
+}
+
+.os-profile-link-btn:hover {
+	background: rgba(0, 212, 255, 0.1);
+	box-shadow: 0 0 6px rgba(0, 212, 255, 0.3);
+	color: var(--os-accent);
+}
+
+/* Navigator Window */
+.os-navigator {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+}
+
+.os-navigator-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 0;
+	border-bottom: 1px solid var(--os-border);
+	margin-bottom: 8px;
+	flex-shrink: 0;
+}
+
+.os-navigator-back {
+	background: transparent;
+	border: 1px solid var(--os-border);
+	color: var(--os-text);
+	width: 24px;
+	height: 24px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 14px;
+	cursor: pointer;
+	transition: background 0.15s;
+}
+
+.os-navigator-back:hover:not(:disabled) {
+	background: var(--os-border);
+}
+
+.os-navigator-back:disabled {
+	opacity: 0.3;
+	cursor: default;
+}
+
+.os-navigator-path {
+	flex: 1;
+	font-size: 12px;
+	color: var(--os-text-dim);
+	background: #0a0a18;
+	padding: 2px 8px;
+	border: 1px solid var(--os-border);
+	font-family: monospace;
+}
+
+.os-navigator-content {
+	flex: 1;
+	overflow: auto;
+	min-height: 0;
+}
+
+.os-navigator-tree {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.os-navigator-folder,
+.os-navigator-file {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 8px;
+	background: transparent;
+	border: none;
+	color: var(--os-text);
+	font-size: 13px;
+	cursor: pointer;
+	text-align: left;
+	width: 100%;
+	transition: background 0.1s;
+}
+
+.os-navigator-folder:hover,
+.os-navigator-file:hover {
+	background: rgba(0, 212, 255, 0.08);
+}
+
+.os-folder-icon,
+.os-file-icon {
+	font-size: 16px;
+	flex-shrink: 0;
+}
+
+.os-file-category {
+	margin-left: auto;
+	font-size: 11px;
+	color: var(--os-text-dim);
+}
+
+.os-navigator-articles {
+	font-size: 13px;
+}
+
+.os-navigator-articles .list {
+	list-style: none;
+	padding: 0;
+}
+
+.os-navigator-articles h2 {
+	font-size: 1.1em;
+	color: var(--os-accent);
+	margin: 12px 0 6px 0;
+	border-bottom: 1px solid var(--os-border);
+	padding-bottom: 4px;
+}
+
+.os-navigator-articles a {
+	color: var(--os-accent);
+}
+
+.os-navigator-tool-detail {
+	overflow: auto;
+}
+
+.os-navigator-tool-content {
+	font-size: 14px;
+}
+
+/* Audio Player Window */
+.os-audio-player {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.os-audio-display {
+	background: #0a0a18;
+	border: 1px solid var(--os-border);
+	padding: 8px 12px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.os-audio-track-name {
+	font-size: 12px;
+	color: var(--os-green);
+	white-space: nowrap;
+}
+
+.os-audio-visualizer {
+	display: flex;
+	align-items: flex-end;
+	gap: 2px;
+	height: 18px;
+}
+
+.os-audio-bar {
+	width: 3px;
+	background: var(--os-accent);
+	transition: height 0.1s ease;
+	min-height: 2px;
+}
+
+.os-audio-controls {
+	display: flex;
+	gap: 4px;
+	justify-content: center;
+}
+
+.os-audio-btn {
+	background: transparent;
+	border: 1px solid var(--os-border);
+	color: var(--os-text);
+	width: 32px;
+	height: 28px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	font-size: 14px;
+	transition: background 0.15s, color 0.15s;
+}
+
+.os-audio-btn:hover {
+	background: var(--os-border);
+	color: var(--os-text-bright);
+}
+
+.os-audio-btn-play {
+	width: 48px;
+	color: var(--os-accent);
+}
+
+/* Visitor Counter in StatusBar */
+.os-statusbar .os-visitor-count {
+	color: var(--os-green);
+	font-variant-numeric: tabular-nums;
+}
+
+/* Sub pages with Window wrapper */
+.os-subpage-workspace {
+	flex: 1;
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	padding: 16px;
+	overflow: auto;
+}
+
+.os-subpage-window {
+	position: relative;
+	width: 100%;
+	max-width: 900px;
+}
+
+/* Responsive */
+@media (max-width: 767px) {
+	.os-desktop-windows {
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 4px;
+	}
+
+	.os-window {
+		position: relative !important;
+		transform: none !important;
+		width: 100% !important;
+		max-height: none;
+	}
+
+	.os-menubar-center {
+		display: none;
+	}
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+	.os-window {
+		max-width: 80vw;
+	}
+}
+
+/* RetroVisitorCounter override for StatusBar */
+.os-statusbar-right .os-visitor-inline {
+	color: var(--os-green);
+	font-size: 11px;
+}


### PR DESCRIPTION
## Summary
- サイト全体をCopland OS風のデスクトップUIにリニューアル
- ドラッグ可能なウィンドウシステム（useDraggable / useWindowManager）を実装
- トップページをProfile / Navigator / AudioPlayerの3ウィンドウ構成に刷新
- 全サブページをWindowコンポーネントでラップして統一的なOS風UIに
- tenori.me → ivgtr.me へのリネーム

## Changes
1. **OS UI基盤**: グローバルCSS、DesktopBackground、MenuBar、StatusBar、MenuBarContext
2. **ウィンドウシステム**: Window コンポーネント、useDraggable / useWindowManager フック
3. **既存コンポーネント適応**: DigitalClock、RetroVisitorCounter をOS UI向けに簡素化
4. **レイアウト移行**: retro-site → os-site、MenuBarProvider 追加
5. **トップページ**: ProfileWindow、NavigatorWindow、AudioPlayerWindow
6. **サブページ**: tools/* / articles を Window でラップ
7. **リネーム**: tenori.me → ivgtr.me

## Test plan
- [ ] トップページで3つのウィンドウが表示・ドラッグ・最小化できること
- [ ] NavigatorWindow からTools/Articlesへのナビゲーションが動作すること
- [ ] AudioPlayerWindow で音声再生・切り替えができること
- [ ] 各サブページ（/tools/*, /articles）がWindow内に正しく表示されること
- [ ] モバイルでドラッグ無効・レスポンシブ表示になること
- [ ] MenuBar にアクティブウィンドウのタイトルが反映されること