### PR TITLE
fix: NavigatorWindow内ツール表示の修正

### DIFF
--- a/src/app/tools/glitch-image/(components)/Stage.tsx
+++ b/src/app/tools/glitch-image/(components)/Stage.tsx
@@ -310,7 +310,7 @@ export const Stage = ({ mode, splitHeight = 40 }: Props) => {
 					)}
 				</div>
 			</div>
-			<div className="flex gap-4 mt-4">
+			<div className="flex flex-wrap gap-2 mt-4">
 				<Button onClick={resetImage} className="bg-gray-500" disabled={!image}>
 					リセット
 				</Button>

--- a/src/app/tools/image-to-base64/(components)/ImageToBase64.tsx
+++ b/src/app/tools/image-to-base64/(components)/ImageToBase64.tsx
@@ -54,7 +54,7 @@ export const ImageToBase64 = () => {
 				</div>
 			</div>
 			<div>
-				{image && <img src={image} alt="preview" />}
+				{image && <img src={image} alt="preview" className="max-w-full h-auto mt-4" />}
 				{image && (
 					<div>
 						<input

--- a/src/app/tools/side-scroller-game/(components)/GameCanvas.tsx
+++ b/src/app/tools/side-scroller-game/(components)/GameCanvas.tsx
@@ -17,43 +17,37 @@ interface CanvasDimensions {
 
 export const GameCanvas = ({ gameState }: GameCanvasProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [canvasDimensions, setCanvasDimensions] = useState<CanvasDimensions>({
     width: GAME_CONSTANTS.CANVAS_WIDTH,
     height: GAME_CONSTANTS.CANVAS_HEIGHT,
   });
 
   useEffect(() => {
-    let timeoutId: NodeJS.Timeout;
-    
+    const container = containerRef.current;
+    if (!container) return;
+
     const updateCanvasSize = () => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => {
-        const isMobile = window.innerWidth < 768;
-        const availableWidth = window.innerWidth - 32;
-        const availableHeight = window.innerHeight * 0.6;
-        
-        if (isMobile) {
-          const aspectRatio = GAME_CONSTANTS.CANVAS_WIDTH / GAME_CONSTANTS.CANVAS_HEIGHT;
-          let width = Math.min(availableWidth, GAME_CONSTANTS.CANVAS_WIDTH);
-          let height = width / aspectRatio;
-          
-          if (height > availableHeight) {
-            height = availableHeight;
-            width = height * aspectRatio;
-          }
-          
-          setCanvasDimensions({ width, height });
-        } else {
-          setCanvasDimensions({ width: GAME_CONSTANTS.CANVAS_WIDTH, height: GAME_CONSTANTS.CANVAS_HEIGHT });
-        }
-      }, 100);
+      const containerWidth = container.clientWidth;
+      const aspectRatio = GAME_CONSTANTS.CANVAS_WIDTH / GAME_CONSTANTS.CANVAS_HEIGHT;
+
+      if (containerWidth < GAME_CONSTANTS.CANVAS_WIDTH) {
+        const width = containerWidth;
+        const height = width / aspectRatio;
+        setCanvasDimensions({ width, height });
+      } else {
+        setCanvasDimensions({ width: GAME_CONSTANTS.CANVAS_WIDTH, height: GAME_CONSTANTS.CANVAS_HEIGHT });
+      }
     };
 
+    const observer = new ResizeObserver(() => {
+      updateCanvasSize();
+    });
+    observer.observe(container);
     updateCanvasSize();
-    window.addEventListener('resize', updateCanvasSize);
+
     return () => {
-      window.removeEventListener('resize', updateCanvasSize);
-      clearTimeout(timeoutId);
+      observer.disconnect();
     };
   }, []);
 
@@ -281,12 +275,14 @@ export const GameCanvas = ({ gameState }: GameCanvasProps) => {
   }, [gameState, canvasDimensions]);
 
   return (
-    <canvas
-      ref={canvasRef}
-      width={canvasDimensions.width}
-      height={canvasDimensions.height}
-      className="border-2 border-gray-400 rounded-lg max-w-full"
-      style={{ display: "block", margin: "0 auto" }}
-    />
+    <div ref={containerRef} style={{ width: "100%" }}>
+      <canvas
+        ref={canvasRef}
+        width={canvasDimensions.width}
+        height={canvasDimensions.height}
+        className="border-2 border-gray-400 rounded-lg max-w-full"
+        style={{ display: "block", margin: "0 auto" }}
+      />
+    </div>
   );
 };

--- a/src/app/tools/tategaki/(components)/Tategaki.tsx
+++ b/src/app/tools/tategaki/(components)/Tategaki.tsx
@@ -66,7 +66,7 @@ export const Tategaki = () => {
 			<div>
 				<h2>入力</h2>
 				<TextArea
-					className="text:"
+					className=""
 					defaultValue={rawText}
 					rows={2}
 					onChange={(e) => setRawText(e.target.value)}
@@ -75,7 +75,7 @@ export const Tategaki = () => {
 
 			<div className="mt-8">
 				<h2>出力</h2>
-				<pre>{rotatedText}</pre>
+				<pre className="overflow-x-auto">{rotatedText}</pre>
 				<Button
 					className="bg-blue-500 mt-4"
 					onClick={() => {

--- a/src/app/tools/x-character-prompt-generator/(components)/XCharacterPromptGenerator.tsx
+++ b/src/app/tools/x-character-prompt-generator/(components)/XCharacterPromptGenerator.tsx
@@ -97,7 +97,7 @@ export const XCharacterPromptGenerator = () => {
 				</div>
 			</div>
 
-			<div className="bg-white rounded-xl shadow-xl p-6">
+			<div className="bg-white rounded-xl shadow-xl p-4">
 				<div className="flex mb-6 border-b">
 					<button
 						onClick={() => setActiveTab("input")}
@@ -262,7 +262,7 @@ export const XCharacterPromptGenerator = () => {
 				)}
 			</div>
 
-			<div className="bg-white rounded-xl shadow-md p-6">
+			<div className="bg-white rounded-xl shadow-md p-4">
 				<h2 className="text-xl font-bold text-gray-800 mb-4">使用方法</h2>
 				<div className="space-y-4">
 					<div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -374,10 +374,12 @@ select {
 table {
 	width: 100%;
 }
-img {
-	max-width: 100%;
-	height: auto;
-	border-radius: 8px;
+@layer base {
+	img {
+		max-width: 100%;
+		height: auto;
+		border-radius: 8px;
+	}
 }
 code {
 	padding: 2px 5px;
@@ -964,6 +966,20 @@ ul.list {
 
 .os-navigator-tool-content {
 	font-size: 14px;
+	overflow: hidden;
+}
+
+.os-navigator-tool-content img {
+	max-width: 100%;
+}
+
+.os-navigator-tool-content canvas {
+	max-width: 100%;
+}
+
+.os-navigator-tool-content pre {
+	overflow-x: auto;
+	max-width: 100%;
 }
 
 /* Audio Player Window */


### PR DESCRIPTION
## Summary
- 各ツールコンポーネントをNavigatorWindowの狭い表示領域に対応（レイアウト調整、ResizeObserver導入等）
- グローバル`img`規則を`@layer base`に移動し、TailwindユーティリティとのCSS Cascade Layers優先度を修正
- `.os-navigator-tool-content`にoverflow制約を追加し、コンテンツの溢れを防止

## Test plan
- [ ] NavigatorWindow → crop-iconで画像がプレビューコンテナ内に収まること
- [ ] NavigatorWindow内の他ツール（ImageToBase64, glitch-image等）で表示が正常なこと
- [ ] スタンドアロンページ（/tools/crop-icon等）での表示に影響がないこと
- [ ] `npm run build`が成功すること