### PR TITLE
feat: add window resize functionality

### DIFF
--- a/.claude/skills/check-design/SKILL.md
+++ b/.claude/skills/check-design/SKILL.md
@@ -46,13 +46,13 @@ Taskツール（`subagent_type: "general-purpose"`）を使ってSubAgentを並�
 1. **デスクトップ確認 (1280x800)**
    - `mcp__playwright__browser_resize` で width: 1280, height: 800 に設定
    - `mcp__playwright__browser_navigate` で対象ページに遷移
-   - `mcp__playwright__browser_take_screenshot` で fullPage: true のスクリーンショットを撮影（filename: "desktop-{パス名}.png"）
+   - `mcp__playwright__browser_take_screenshot` で fullPage: true のスクリーンショットを撮影（filename: ".playwright-mcp/desktop-{パス名}.png"）
    - `mcp__playwright__browser_snapshot` でアクセシビリティスナップショットを取得
    - `mcp__playwright__browser_console_messages` で level: "warning" のコンソールメッセージを確認
 
 2. **モバイル確認 (375x667)**
    - `mcp__playwright__browser_resize` で width: 375, height: 667 に設定
-   - `mcp__playwright__browser_take_screenshot` で fullPage: true のスクリーンショットを撮影（filename: "mobile-{パス名}.png"）
+   - `mcp__playwright__browser_take_screenshot` で fullPage: true のスクリーンショットを撮影（filename: ".playwright-mcp/mobile-{パス名}.png"）
    - `mcp__playwright__browser_snapshot` でアクセシビリティスナップショットを取得
 
 3. **ページごとの評価**を以下の観点で実施:

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,8 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# development screenshots
-copland-os-*.png
-
 # playwright mcp
 .playwright-mcp/
+/*.png
+/*.jpeg
+/*.jpg

--- a/README.md
+++ b/README.md
@@ -1,50 +1,21 @@
 <div align="center">
 
-# 🌟 ivgtr.me
+## 🍣 ivgtr.me
 
-_ivgtr's personal portfolio website_
+_theme: retro OS_
 
 [![🌐 Live Site](https://img.shields.io/badge/🌐_Live_Site-ivgtr.me-4A90E2?style=for-the-badge)](https://ivgtr.me)
 
 [![Bluesky](https://img.shields.io/badge/Bluesky-0285FF?style=for-the-badge&logo=bluesky&logoColor=fff)](https://bsky.ivgtr.me/)
+[![Twitter](https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white)](https://twitter.com/ivgtr)
 [![GitHub](https://img.shields.io/badge/GitHub-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ivgtr)
-
----
-
-</div>
-
-## 🔧 Development
-
-### Getting Started
-
-```bash
-# Clone and install
-git clone https://github.com/ivgtr/ivgtr.me.git
-cd ivgtr.me
-npm install
-
-# Set up environment
-echo "DB_URL=your_neon_database_url" > .env.local
-
-# Start development
-npm run dev
-```
-
-### Available Scripts
-
-| Command         | Description                             |
-| --------------- | --------------------------------------- |
-| `npm run dev`   | Start development server with Turbopack |
-| `npm run build` | Build for production                    |
-| `npm run start` | Start production server                 |
-| `npm run lint`  | Run ESLint                              |
 
 ---
 
 <div align="center">
 
-## 📄 License
+### 📄 License
 
-**MIT** ©[ivgtr](https://github.com/ivgtr)
+MIT License © [ivgtr](https://ivgtr.me)
 
 </div>

--- a/src/hooks/useResizable.ts
+++ b/src/hooks/useResizable.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+interface Size {
+  width: number;
+  height: number | undefined;
+}
+
+interface UseResizableOptions {
+  defaultSize: { width: number; height?: number };
+  minSize?: { width: number; height: number };
+  disabled?: boolean;
+}
+
+type ResizeDirection = "e" | "s" | "se";
+
+export function useResizable({
+  defaultSize,
+  minSize = { width: 200, height: 100 },
+  disabled = false,
+}: UseResizableOptions) {
+  const [size, setSize] = useState<Size>({
+    width: defaultSize.width,
+    height: defaultSize.height,
+  });
+  const isResizing = useRef(false);
+  const [isResizingState, setIsResizingState] = useState(false);
+  const directionRef = useRef<ResizeDirection>("se");
+  const startPos = useRef({ x: 0, y: 0 });
+  const startSize = useRef<Size>({ width: 0, height: undefined });
+
+  const handlePointerDown = useCallback(
+    (direction: ResizeDirection) => (e: React.PointerEvent) => {
+      if (disabled) return;
+      e.stopPropagation();
+      isResizing.current = true;
+      setIsResizingState(true);
+      directionRef.current = direction;
+      startPos.current = { x: e.clientX, y: e.clientY };
+      startSize.current = { width: size.width, height: size.height };
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [disabled, size],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isResizing.current) return;
+      const dx = e.clientX - startPos.current.x;
+      const dy = e.clientY - startPos.current.y;
+      const dir = directionRef.current;
+
+      setSize((prev) => {
+        const newSize = { ...prev };
+        if (dir === "e" || dir === "se") {
+          newSize.width = Math.max(minSize.width, (startSize.current.width) + dx);
+        }
+        if (dir === "s" || dir === "se") {
+          const startH = startSize.current.height ?? 0;
+          if (startH > 0) {
+            newSize.height = Math.max(minSize.height, startH + dy);
+          }
+        }
+        return newSize;
+      });
+    },
+    [minSize],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    isResizing.current = false;
+    setIsResizingState(false);
+  }, []);
+
+  const resizeHandleProps = useCallback(
+    (direction: ResizeDirection) =>
+      disabled
+        ? {}
+        : {
+            onPointerDown: handlePointerDown(direction),
+            onPointerMove: handlePointerMove,
+            onPointerUp: handlePointerUp,
+          },
+    [disabled, handlePointerDown, handlePointerMove, handlePointerUp],
+  );
+
+  const sizeStyle: React.CSSProperties = {
+    width: `${size.width}px`,
+    height: size.height != null ? `${size.height}px` : undefined,
+  };
+
+  return {
+    size,
+    isResizing: isResizingState,
+    resizeHandleProps,
+    sizeStyle,
+  };
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -758,6 +758,49 @@ ul.list {
 	font-size: 14px;
 }
 
+/* Resize Handles */
+.os-resize-handle {
+	position: absolute;
+	z-index: 10;
+	touch-action: none;
+}
+
+.os-resize-handle-e {
+	right: 0;
+	top: 0;
+	bottom: 0;
+	width: 6px;
+	cursor: ew-resize;
+}
+
+.os-resize-handle-s {
+	left: 0;
+	right: 0;
+	bottom: 0;
+	height: 6px;
+	cursor: ns-resize;
+}
+
+.os-resize-handle-se {
+	right: 0;
+	bottom: 0;
+	width: 12px;
+	height: 12px;
+	cursor: nwse-resize;
+}
+
+.os-resize-handle-se::after {
+	content: "";
+	position: absolute;
+	right: 2px;
+	bottom: 2px;
+	width: 0;
+	height: 0;
+	border-style: solid;
+	border-width: 0 0 8px 8px;
+	border-color: transparent transparent var(--os-border) transparent;
+}
+
 /* Profile Window */
 .os-profile {
 	display: flex;
@@ -1073,6 +1116,10 @@ ul.list {
 	}
 
 	.os-menubar-center {
+		display: none;
+	}
+
+	.os-resize-handle {
 		display: none;
 	}
 }


### PR DESCRIPTION
## Summary
- READMEの簡略化、Playwright MCP スクリーンショットの出力先変更
- Windowコンポーネントにリサイズ機能を追加（PC表示時のみ、右端・下端・右下角のドラッグでサイズ変更可能）

## Test plan
- [ ] デスクトップ表示でウィンドウの右端・下端・右下角をドラッグしてリサイズできることを確認
- [ ] minSize以下に縮小できないことを確認
- [ ] モバイル表示でリサイズハンドルが非表示であることを確認
- [ ] `npm run build` でビルドエラーがないことを確認