### PR TITLE
feat: OS風UI改善 - ウィンドウ管理・ブートアニメーション・レイアウト修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import "@/styles/globals.css";
 import { DesktopBackground } from "@/components/os/DesktopBackground";
 import { KonamiProvider } from "@/components/retro/KonamiProvider";
 import { MenuBarProvider } from "@/components/os/MenuBarContext";
+import { BootSequenceProvider } from "@/components/os/BootSequenceContext";
 import { MenuBar } from "@/components/os/MenuBar";
 
 export const metadata: Metadata = {
@@ -25,9 +26,11 @@ export default function RootLayout({
 			<body className={`${marumonica.variable} ${aahub.variable} os-site`}>
 				<KonamiProvider>
 					<MenuBarProvider>
-						<DesktopBackground />
-						<MenuBar />
-						<main className="os-workspace">{children}</main>
+						<BootSequenceProvider>
+							<DesktopBackground />
+							<MenuBar />
+							<main className="os-workspace">{children}</main>
+						</BootSequenceProvider>
 					</MenuBarProvider>
 				</KonamiProvider>
 			</body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { StatusBar } from "@/components/os/StatusBar";
 import { DesktopIcons } from "@/components/os/DesktopIcons";
 import { useWindowManager } from "@/hooks/useWindowManager";
 import { useMenuBar } from "@/components/os/MenuBarContext";
+import { useBootSequence } from "@/components/os/BootSequenceContext";
 import { ProfileWindow } from "./(components)/ProfileWindow";
 import { NavigatorWindow } from "./(components)/NavigatorWindow";
 import { AudioPlayerWindow } from "./(components)/AudioPlayerWindow";
@@ -100,18 +101,24 @@ const shortTitles: Record<string, string> = {
 
 export default function Home() {
 	const [randomPositions, setRandomPositions] = useState<Record<string, { x: number; y: number }> | null>(null);
+	const [isReady, setIsReady] = useState(false);
 
 	const { windows, focus, close, minimize, restore, open, getWindow, updatePosition } =
 		useWindowManager(initialWindows);
 	const { setActiveTitle } = useMenuBar();
+	const { isPhaseReached, isComplete } = useBootSequence();
 
 	useEffect(() => {
-		if (window.innerWidth < 768) return;
+		if (window.innerWidth < 768) {
+			setIsReady(true);
+			return;
+		}
 		const newPositions = calculateRandomPositions();
 		for (const [id, pos] of Object.entries(newPositions)) {
 			updatePosition(id, pos);
 		}
 		setRandomPositions(newPositions);
+		setIsReady(true);
 	}, [updatePosition]);
 
 	const profileWin = getWindow("profile")!;
@@ -179,58 +186,68 @@ export default function Home() {
 		onClose: () => close(w.id),
 	}));
 
+	const showWindows = isReady && isPhaseReached("windows");
+	const staggerBase = isComplete ? 0 : 200;
+
 	return (
 		<>
 			<div className="os-desktop-windows">
-				<DesktopIcons icons={desktopIconData} />
+				<DesktopIcons icons={desktopIconData} visible={isPhaseReached("icons")} />
 
-				<Window
-					id="profile"
-					title="Profile - ivgtr"
-					defaultPosition={profileWin.position}
-					position={randomPositions?.profile}
-					defaultSize={{ width: 320 }}
-					isOpen={profileWin.isOpen}
-					isMinimized={profileWin.isMinimized}
-					zIndex={profileWin.zIndex}
-					onClose={() => close("profile")}
-					onMinimize={() => minimize("profile")}
-					onFocus={() => focus("profile")}
-				>
-					<ProfileWindow />
-				</Window>
+				{showWindows && (
+					<>
+						<Window
+							id="profile"
+							title="Profile - ivgtr"
+							defaultPosition={profileWin.position}
+							position={randomPositions?.profile}
+							defaultSize={{ width: 320 }}
+							isOpen={profileWin.isOpen}
+							isMinimized={profileWin.isMinimized}
+							zIndex={profileWin.zIndex}
+							staggerDelay={staggerBase * 0}
+							onClose={() => close("profile")}
+							onMinimize={() => minimize("profile")}
+							onFocus={() => focus("profile")}
+						>
+							<ProfileWindow />
+						</Window>
 
-				<Window
-					id="navigator"
-					title="Navigator - /home/ivgtr/"
-					defaultPosition={navigatorWin.position}
-					position={randomPositions?.navigator}
-					defaultSize={{ width: 520, height: 420 }}
-					isOpen={navigatorWin.isOpen}
-					isMinimized={navigatorWin.isMinimized}
-					zIndex={navigatorWin.zIndex}
-					onClose={() => close("navigator")}
-					onMinimize={() => minimize("navigator")}
-					onFocus={() => focus("navigator")}
-				>
-					<NavigatorWindow />
-				</Window>
+						<Window
+							id="navigator"
+							title="Navigator - /home/ivgtr/"
+							defaultPosition={navigatorWin.position}
+							position={randomPositions?.navigator}
+							defaultSize={{ width: 520, height: 420 }}
+							isOpen={navigatorWin.isOpen}
+							isMinimized={navigatorWin.isMinimized}
+							zIndex={navigatorWin.zIndex}
+							staggerDelay={staggerBase * 1}
+							onClose={() => close("navigator")}
+							onMinimize={() => minimize("navigator")}
+							onFocus={() => focus("navigator")}
+						>
+							<NavigatorWindow />
+						</Window>
 
-				<Window
-					id="audio"
-					title="Audio Player"
-					defaultPosition={audioWin.position}
-					position={randomPositions?.audio}
-					defaultSize={{ width: 340 }}
-					isOpen={audioWin.isOpen}
-					isMinimized={audioWin.isMinimized}
-					zIndex={audioWin.zIndex}
-					onClose={() => close("audio")}
-					onMinimize={() => minimize("audio")}
-					onFocus={() => focus("audio")}
-				>
-					<AudioPlayerWindow />
-				</Window>
+						<Window
+							id="audio"
+							title="Audio Player"
+							defaultPosition={audioWin.position}
+							position={randomPositions?.audio}
+							defaultSize={{ width: 340 }}
+							isOpen={audioWin.isOpen}
+							isMinimized={audioWin.isMinimized}
+							zIndex={audioWin.zIndex}
+							staggerDelay={staggerBase * 2}
+							onClose={() => close("audio")}
+							onMinimize={() => minimize("audio")}
+							onFocus={() => focus("audio")}
+						>
+							<AudioPlayerWindow />
+						</Window>
+					</>
+				)}
 			</div>
 
 			<StatusBar taskbarWindows={taskbarWindows} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -170,6 +170,7 @@ export default function Home() {
 		{ id: "audio", label: "Audio", icon: faMusic },
 	].map((item) => ({
 		...item,
+		onClick: () => handleOpenFromIcon(item.id),
 		onDoubleClick: () => handleOpenFromIcon(item.id),
 	}));
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,20 +41,11 @@ export default function Home() {
 	const { setActiveTitle } = useMenuBar();
 
 	useEffect(() => {
-		const vw = window.innerWidth;
-		const vh = window.innerHeight;
-		const windowSizes: Record<string, { w: number; h: number }> = {
-			profile: { w: 320, h: 400 },
-			navigator: { w: 520, h: 420 },
-			audio: { w: 340, h: 200 },
-		};
-
 		const newPositions: Record<string, { x: number; y: number }> = {};
 		for (const [id, base] of Object.entries(basePositions)) {
-			const size = windowSizes[id] ?? { w: 400, h: 400 };
 			const pos = {
-				x: Math.max(0, Math.min(base.x + randomOffset(RANDOM_OFFSET_RANGE), vw - size.w)),
-				y: Math.max(0, Math.min(base.y + randomOffset(RANDOM_OFFSET_RANGE), vh - size.h)),
+				x: base.x + randomOffset(RANDOM_OFFSET_RANGE),
+				y: Math.max(0, base.y + randomOffset(RANDOM_OFFSET_RANGE)),
 			};
 			newPositions[id] = pos;
 			updatePosition(id, pos);

--- a/src/components/os/BootSequenceContext.tsx
+++ b/src/components/os/BootSequenceContext.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+export type BootPhase = "idle" | "background" | "menubar" | "statusbar" | "windows" | "icons" | "complete";
+
+const PHASE_ORDER: BootPhase[] = ["idle", "background", "menubar", "statusbar", "windows", "icons", "complete"];
+
+interface BootSequenceContextValue {
+	phase: BootPhase;
+	isComplete: boolean;
+	isPhaseReached: (target: BootPhase) => boolean;
+}
+
+const BootSequenceContext = createContext<BootSequenceContextValue>({
+	phase: "complete",
+	isComplete: true,
+	isPhaseReached: () => true,
+});
+
+export function useBootSequence() {
+	return useContext(BootSequenceContext);
+}
+
+const PHASE_TIMINGS: { phase: BootPhase; delay: number }[] = [
+	{ phase: "background", delay: 100 },
+	{ phase: "menubar", delay: 300 },
+	{ phase: "statusbar", delay: 600 },
+	{ phase: "windows", delay: 800 },
+	{ phase: "icons", delay: 1200 },
+	{ phase: "complete", delay: 1400 },
+];
+
+export function BootSequenceProvider({ children }: { children: ReactNode }) {
+	const [phase, setPhase] = useState<BootPhase>("idle");
+
+	useEffect(() => {
+		const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		if (prefersReducedMotion) {
+			setPhase("complete");
+			return;
+		}
+
+		const timers: ReturnType<typeof setTimeout>[] = [];
+		for (const { phase: p, delay } of PHASE_TIMINGS) {
+			timers.push(setTimeout(() => setPhase(p), delay));
+		}
+
+		return () => {
+			for (const t of timers) clearTimeout(t);
+		};
+	}, []);
+
+	const isComplete = phase === "complete";
+
+	const isPhaseReached = (target: BootPhase): boolean => {
+		return PHASE_ORDER.indexOf(phase) >= PHASE_ORDER.indexOf(target);
+	};
+
+	return (
+		<BootSequenceContext.Provider value={{ phase, isComplete, isPhaseReached }}>
+			{children}
+		</BootSequenceContext.Provider>
+	);
+}

--- a/src/components/os/DesktopBackground.tsx
+++ b/src/components/os/DesktopBackground.tsx
@@ -1,3 +1,17 @@
+"use client";
+
+import { useBootSequence } from "@/components/os/BootSequenceContext";
+
 export const DesktopBackground = () => {
-  return <div className="os-desktop-bg" />;
+	const { isPhaseReached, isComplete } = useBootSequence();
+
+	const className = [
+		"os-desktop-bg",
+		!isComplete && !isPhaseReached("background") ? "os-boot-hidden" : "",
+		!isComplete && isPhaseReached("background") ? "os-boot-fade-in" : "",
+	]
+		.filter(Boolean)
+		.join(" ");
+
+	return <div className={className} />;
 };

--- a/src/components/os/DesktopIcons.tsx
+++ b/src/components/os/DesktopIcons.tsx
@@ -12,11 +12,19 @@ interface DesktopIcon {
 
 interface DesktopIconsProps {
 	icons: DesktopIcon[];
+	visible?: boolean;
 }
 
-export const DesktopIcons = ({ icons }: DesktopIconsProps) => {
+export const DesktopIcons = ({ icons, visible = true }: DesktopIconsProps) => {
+	const className = [
+		"os-desktop-icons",
+		!visible ? "os-boot-hidden" : "os-boot-fade-in",
+	]
+		.filter(Boolean)
+		.join(" ");
+
 	return (
-		<div className="os-desktop-icons">
+		<div className={className}>
 			{icons.map((item) => (
 				<button
 					key={item.id}

--- a/src/components/os/DesktopIcons.tsx
+++ b/src/components/os/DesktopIcons.tsx
@@ -7,7 +7,8 @@ interface DesktopIcon {
 	id: string;
 	label: string;
 	icon: IconDefinition;
-	onDoubleClick: () => void;
+	onClick?: () => void;
+	onDoubleClick?: () => void;
 }
 
 interface DesktopIconsProps {
@@ -29,6 +30,7 @@ export const DesktopIcons = ({ icons, visible = true }: DesktopIconsProps) => {
 				<button
 					key={item.id}
 					className="os-desktop-icon"
+					onClick={item.onClick}
 					onDoubleClick={item.onDoubleClick}
 				>
 					<FontAwesomeIcon icon={item.icon} className="os-desktop-icon-fa" />

--- a/src/components/os/DesktopIcons.tsx
+++ b/src/components/os/DesktopIcons.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface DesktopIcon {
+	id: string;
+	label: string;
+	icon: IconDefinition;
+	onDoubleClick: () => void;
+}
+
+interface DesktopIconsProps {
+	icons: DesktopIcon[];
+}
+
+export const DesktopIcons = ({ icons }: DesktopIconsProps) => {
+	return (
+		<div className="os-desktop-icons">
+			{icons.map((item) => (
+				<button
+					key={item.id}
+					className="os-desktop-icon"
+					onDoubleClick={item.onDoubleClick}
+				>
+					<FontAwesomeIcon icon={item.icon} className="os-desktop-icon-fa" />
+					<span className="os-desktop-icon-label">{item.label}</span>
+				</button>
+			))}
+		</div>
+	);
+};

--- a/src/components/os/MenuBar.tsx
+++ b/src/components/os/MenuBar.tsx
@@ -3,12 +3,22 @@
 import Link from "next/link";
 import { DigitalClock } from "@/components/retro/DigitalClock";
 import { useMenuBar } from "@/components/os/MenuBarContext";
+import { useBootSequence } from "@/components/os/BootSequenceContext";
 
 export const MenuBar = () => {
   const { activeTitle } = useMenuBar();
+  const { isPhaseReached, isComplete } = useBootSequence();
+
+  const className = [
+    "os-menubar",
+    !isComplete && !isPhaseReached("menubar") ? "os-boot-hidden" : "",
+    !isComplete && isPhaseReached("menubar") ? "os-boot-slide-down" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
-    <nav className="os-menubar">
+    <nav className={className}>
       <div className="os-menubar-left">
         <Link href="/" className="os-menubar-brand">
           ivgtr.me

--- a/src/components/os/StatusBar.tsx
+++ b/src/components/os/StatusBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { RetroVisitorCounter } from "@/components/retro/RetroVisitorCounter";
+import { useBootSequence } from "@/components/os/BootSequenceContext";
 
 interface TaskbarWindow {
 	id: string;
@@ -20,10 +21,19 @@ interface StatusBarProps {
 }
 
 export const StatusBar = ({ taskbarWindows = [] }: StatusBarProps) => {
+	const { isPhaseReached, isComplete } = useBootSequence();
 	const visibleWindows = taskbarWindows.filter((w) => w.isOpen);
 
+	const barClassName = [
+		"os-statusbar",
+		!isComplete && !isPhaseReached("statusbar") ? "os-boot-hidden" : "",
+		!isComplete && isPhaseReached("statusbar") ? "os-boot-slide-up" : "",
+	]
+		.filter(Boolean)
+		.join(" ");
+
 	return (
-		<div className="os-statusbar">
+		<div className={barClassName}>
 			<div className="os-statusbar-left">
 				<span className="os-statusbar-indicator" />
 				<span>Connection: OK</span>

--- a/src/components/os/StatusBar.tsx
+++ b/src/components/os/StatusBar.tsx
@@ -2,37 +2,74 @@
 
 import { RetroVisitorCounter } from "@/components/retro/RetroVisitorCounter";
 
-interface MinimizedWindow {
-  id: string;
-  title: string;
-  onRestore: () => void;
+interface TaskbarWindow {
+	id: string;
+	title: string;
+	isOpen: boolean;
+	isMinimized: boolean;
+	isActive: boolean;
+	closable: boolean;
+	onFocus: () => void;
+	onMinimize: () => void;
+	onRestore: () => void;
+	onClose: () => void;
 }
 
 interface StatusBarProps {
-  minimizedWindows?: MinimizedWindow[];
+	taskbarWindows?: TaskbarWindow[];
 }
 
-export const StatusBar = ({ minimizedWindows = [] }: StatusBarProps) => {
-  return (
-    <div className="os-statusbar">
-      <div className="os-statusbar-left">
-        <span className="os-statusbar-indicator" />
-        <span>Connection: OK</span>
-      </div>
-      <div className="os-statusbar-center">
-        {minimizedWindows.map((w) => (
-          <button
-            key={w.id}
-            className="os-statusbar-window-btn"
-            onClick={w.onRestore}
-          >
-            {w.title}
-          </button>
-        ))}
-      </div>
-      <div className="os-statusbar-right">
-        <RetroVisitorCounter />
-      </div>
-    </div>
-  );
+export const StatusBar = ({ taskbarWindows = [] }: StatusBarProps) => {
+	const visibleWindows = taskbarWindows.filter((w) => w.isOpen);
+
+	return (
+		<div className="os-statusbar">
+			<div className="os-statusbar-left">
+				<span className="os-statusbar-indicator" />
+				<span>Connection: OK</span>
+			</div>
+			<div className="os-statusbar-center">
+				{visibleWindows.map((w) => {
+					const className = [
+						"os-taskbar-btn",
+						w.isActive && !w.isMinimized ? "os-taskbar-btn--active" : "",
+						w.isMinimized ? "os-taskbar-btn--minimized" : "",
+					]
+						.filter(Boolean)
+						.join(" ");
+
+					const handleClick = () => {
+						if (w.isMinimized) {
+							w.onRestore();
+						} else if (w.isActive) {
+							w.onMinimize();
+						} else {
+							w.onFocus();
+						}
+					};
+
+					const handleContextMenu = (e: React.MouseEvent) => {
+						e.preventDefault();
+						if (w.closable) {
+							w.onClose();
+						}
+					};
+
+					return (
+						<button
+							key={w.id}
+							className={className}
+							onClick={handleClick}
+							onContextMenu={handleContextMenu}
+						>
+							{w.title}
+						</button>
+					);
+				})}
+			</div>
+			<div className="os-statusbar-right">
+				<RetroVisitorCounter />
+			</div>
+		</div>
+	);
 };

--- a/src/components/os/Window.tsx
+++ b/src/components/os/Window.tsx
@@ -9,6 +9,7 @@ interface WindowProps {
   title: string;
   children: React.ReactNode;
   defaultPosition?: { x: number; y: number };
+  position?: { x: number; y: number };
   defaultSize?: { width: number | string; height?: number | string };
   isOpen?: boolean;
   isMinimized?: boolean;
@@ -26,6 +27,7 @@ export const Window = ({
   title,
   children,
   defaultPosition = { x: 0, y: 0 },
+  position: controlledPosition,
   defaultSize,
   isOpen = true,
   isMinimized = false,
@@ -46,10 +48,16 @@ export const Window = ({
     return () => window.removeEventListener("resize", check);
   }, []);
 
-  const { elementRef, dragHandleProps, style: dragStyle } = useDraggable({
+  const { elementRef, dragHandleProps, style: dragStyle, setPosition } = useDraggable({
     defaultPosition,
     disabled: isMobile,
   });
+
+  useEffect(() => {
+    if (controlledPosition) {
+      setPosition(controlledPosition);
+    }
+  }, [controlledPosition, setPosition]);
 
   const shouldEnableResize = resizable && !isMobile;
 

--- a/src/components/os/Window.tsx
+++ b/src/components/os/Window.tsx
@@ -116,18 +116,6 @@ export const Window = ({
     >
       <div className="os-titlebar" {...dragHandleProps}>
         <div className="os-titlebar-buttons">
-          {minimizable && (
-            <button
-              className="os-titlebar-btn os-titlebar-btn-minimize"
-              onClick={(e) => {
-                e.stopPropagation();
-                onMinimize?.();
-              }}
-              aria-label="最小化"
-            >
-              <span>_</span>
-            </button>
-          )}
           {closable && (
             <button
               className="os-titlebar-btn os-titlebar-btn-close"
@@ -138,6 +126,18 @@ export const Window = ({
               aria-label="閉じる"
             >
               <span>&times;</span>
+            </button>
+          )}
+          {minimizable && (
+            <button
+              className="os-titlebar-btn os-titlebar-btn-minimize"
+              onClick={(e) => {
+                e.stopPropagation();
+                onMinimize?.();
+              }}
+              aria-label="最小化"
+            >
+              <span>_</span>
             </button>
           )}
         </div>

--- a/src/components/os/index.ts
+++ b/src/components/os/index.ts
@@ -2,3 +2,4 @@ export { Window } from "./Window";
 export { MenuBar } from "./MenuBar";
 export { StatusBar } from "./StatusBar";
 export { DesktopBackground } from "./DesktopBackground";
+export { DesktopIcons } from "./DesktopIcons";

--- a/src/hooks/useDraggable.ts
+++ b/src/hooks/useDraggable.ts
@@ -37,20 +37,7 @@ export function useDraggable({ defaultPosition = { x: 0, y: 0 }, disabled = fals
       let newX = e.clientX - dragStart.current.x;
       let newY = e.clientY - dragStart.current.y;
 
-      const el = elementRef.current;
-      if (el) {
-        const rect = el.getBoundingClientRect();
-        const parentRect = el.offsetParent?.getBoundingClientRect() ?? {
-          left: 0,
-          top: 0,
-          width: window.innerWidth,
-          height: window.innerHeight,
-        };
-        const maxX = parentRect.width - rect.width;
-        const maxY = parentRect.height - rect.height;
-        newX = Math.max(0, Math.min(newX, maxX));
-        newY = Math.max(0, Math.min(newY, maxY));
-      }
+      newY = Math.max(0, newY);
 
       setPosition({ x: newX, y: newY });
     },

--- a/src/hooks/useWindowManager.ts
+++ b/src/hooks/useWindowManager.ts
@@ -71,5 +71,11 @@ export function useWindowManager(initialWindows: Omit<WindowState, "zIndex">[]) 
     [windows],
   );
 
-  return { windows, focus, close, minimize, restore, open, getWindow };
+  const updatePosition = useCallback(
+    (id: string, position: { x: number; y: number }) =>
+      dispatch({ type: "updatePosition", id, position }),
+    [],
+  );
+
+  return { windows, focus, close, minimize, restore, open, getWindow, updatePosition };
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -619,23 +619,34 @@ ul.list {
 	gap: 4px;
 	overflow-x: auto;
 	flex: 1;
-	justify-content: center;
+	justify-content: flex-start;
 }
 
-.os-statusbar-window-btn {
+.os-taskbar-btn {
 	background: rgba(0, 212, 255, 0.1);
 	border: 1px solid var(--os-border);
 	color: var(--os-text);
 	font-size: 11px;
 	padding: 1px 8px;
 	cursor: pointer;
-	transition: background 0.15s;
+	transition: background 0.15s, border-color 0.15s, opacity 0.15s;
 	white-space: nowrap;
 }
 
-.os-statusbar-window-btn:hover {
+.os-taskbar-btn:hover {
 	background: rgba(0, 212, 255, 0.2);
 	color: var(--os-text-bright);
+}
+
+.os-taskbar-btn--active {
+	background: rgba(0, 212, 255, 0.2);
+	border-color: var(--os-accent);
+	color: var(--os-text-bright);
+}
+
+.os-taskbar-btn--minimized {
+	opacity: 0.5;
+	border-style: dashed;
 }
 
 .os-statusbar-right {
@@ -657,6 +668,50 @@ ul.list {
 	flex-direction: column;
 	max-width: 100%;
 	margin: 0;
+}
+
+/* Desktop icons */
+.os-desktop-icons {
+	position: absolute;
+	top: 12px;
+	left: 12px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	z-index: 1;
+}
+
+.os-desktop-icon {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 4px;
+	width: 72px;
+	padding: 6px 4px;
+	background: transparent;
+	border: 1px solid transparent;
+	color: var(--os-text);
+	cursor: default;
+	font-size: 10px;
+	transition: background 0.15s, border-color 0.15s;
+}
+
+.os-desktop-icon:hover {
+	background: rgba(0, 212, 255, 0.08);
+	border-color: var(--os-border);
+}
+
+.os-desktop-icon-fa {
+	font-size: 28px;
+	color: var(--os-accent);
+	filter: drop-shadow(0 0 4px rgba(0, 212, 255, 0.3));
+}
+
+.os-desktop-icon-label {
+	text-align: center;
+	word-break: break-word;
+	line-height: 1.2;
+	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
 }
 
 /* Desktop windows container (used on home page) */
@@ -1125,6 +1180,10 @@ ul.list {
 
 /* Responsive */
 @media (max-width: 767px) {
+	.os-desktop-icons {
+		display: none;
+	}
+
 	.os-desktop-windows {
 		overflow-y: auto;
 		display: flex;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1214,6 +1214,65 @@ ul.list {
 	}
 }
 
+/* Boot Sequence Animations */
+.os-boot-hidden {
+	opacity: 0;
+	visibility: hidden;
+}
+
+@keyframes os-boot-fade-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes os-boot-slide-down {
+	from { opacity: 0; transform: translateY(-100%); }
+	to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes os-boot-slide-up {
+	from { opacity: 0; transform: translateY(100%); }
+	to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes os-window-stagger-in {
+	from { opacity: 0; transform: scale(0.95); }
+	to { opacity: 1; transform: scale(1); }
+}
+
+.os-boot-fade-in {
+	animation: os-boot-fade-in 0.3s ease-out forwards;
+}
+
+.os-boot-slide-down {
+	animation: os-boot-slide-down 0.3s ease-out forwards;
+}
+
+.os-boot-slide-up {
+	animation: os-boot-slide-up 0.3s ease-out forwards;
+}
+
+.os-window-stagger-in {
+	animation: os-window-stagger-in 0.3s ease-out backwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.os-boot-fade-in,
+	.os-boot-slide-down,
+	.os-boot-slide-up,
+	.os-window-stagger-in {
+		animation: none;
+		opacity: 1;
+		transform: none;
+		visibility: visible;
+	}
+
+	.os-boot-hidden {
+		opacity: 1;
+		visibility: visible;
+	}
+}
+
 /* RetroVisitorCounter override for StatusBar */
 .os-statusbar-right .os-visitor-inline {
 	color: var(--os-green);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1181,7 +1181,31 @@ ul.list {
 /* Responsive */
 @media (max-width: 767px) {
 	.os-desktop-icons {
-		display: none;
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		flex-direction: row;
+		flex-wrap: wrap;
+		align-content: flex-start;
+		justify-content: flex-start;
+		gap: 4px;
+		padding: 8px 4px;
+		z-index: 0;
+		pointer-events: none;
+	}
+
+	.os-desktop-icon {
+		width: auto;
+		min-width: 64px;
+		padding: 4px 8px;
+		font-size: 9px;
+		pointer-events: auto;
+	}
+
+	.os-desktop-icon-fa {
+		font-size: 22px;
 	}
 
 	.os-desktop-windows {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1007,6 +1007,31 @@ ul.list {
 
 .os-navigator-tool-content {
 	font-size: 14px;
+	padding: 8px 12px;
+}
+
+/* Navigator内 crop-icon等ツールのレイアウト調整 */
+.os-navigator-tool-content .relative.h-72.mt-12 {
+	margin-top: 0;
+	height: 12rem;
+	overflow: hidden;
+	background: rgba(10, 10, 24, 0.8);
+	border-radius: 4px;
+	border: 1px solid var(--os-border);
+}
+
+.os-navigator-tool-content .relative.h-72.mt-12 img {
+	height: 100%;
+	object-fit: contain;
+}
+
+.os-navigator-tool-content input,
+.os-navigator-tool-content select {
+	min-width: 0;
+	box-sizing: border-box;
+	border-color: var(--os-border);
+	color: var(--os-text-bright);
+	background: #0a0a18;
 }
 
 /* Audio Player Window */


### PR DESCRIPTION
## Summary
- Navigator内ツールページのレイアウト崩れを修正
- PC表示でウィンドウ初期位置にランダム性を追加し、画面サイズに応じた動的グリッド配置に改善
- ウィンドウの画面外移動制約を上方向のみに緩和
- タスクバー風StatusBarとデスクトップアイコンを実装
- タイトルバーの閉じる/最小化ボタンの順序を入れ替え
- OS起動風ブートシーケンスアニメーション（MenuBar→背景→StatusBar→ウィンドウスタガー→アイコン）を実装
- ウィンドウ初期配置のちらつき（fallback座標→ランダム座標へのジャンプ）を防止

## Test plan
- [ ] PC表示（768px以上）でページリロード → ブートシーケンスアニメーションが段階的に再生される
- [ ] ウィンドウがちらつきなく正しいランダム位置に表示される
- [ ] ウィンドウの閉じる→再度開く操作で通常アニメーションが正常動作する
- [ ] モバイル表示（767px以下）で正常に表示される
- [ ] `prefers-reduced-motion` 設定時にアニメーションがスキップされる